### PR TITLE
Fixing bug #118 that's caused by a typo with the parentRatingKey/grandParentRatingKey

### DIFF
--- a/modules/statistics.go
+++ b/modules/statistics.go
@@ -256,7 +256,7 @@ func WrapperrDownloadDays(ID int, wrapperr_data []models.WrapperrDay, loop_inter
 						var parentRatingKey int = 0
 						parentRatingKeyInt, err := strconv.Atoi(fmt.Sprintf("%v", tautulli_data[j].ParentRatingKey))
 						if err == nil {
-							grandparentRatingKey = parentRatingKeyInt
+							parentRatingKey = parentRatingKeyInt
 						}
 
 						var ratingKey int = 0


### PR DESCRIPTION
I finally hit a case where this bug caused an issue, so I've fixed it. I need this fixed to support another new feature that I'm working on.